### PR TITLE
Create Kenwood_DMX4704s.ir file for automobile head unit

### DIFF
--- a/Car_Multimedia/CD_Players/Kenwood/Kenwood_DMX4704s.ir
+++ b/Car_Multimedia/CD_Players/Kenwood/Kenwood_DMX4704s.ir
@@ -2,7 +2,7 @@ Filetype: IR signals file
 Version: 1
 # 
 # Remote: Kenwood 
-# Model: Kenwood DMX4707s
+# Model: Kenwood DMX4707s headunit
 #
 name: Src
 type: parsed

--- a/Car_Multimedia/CD_Players/Kenwood/Kenwood_DMX4704s.ir
+++ b/Car_Multimedia/CD_Players/Kenwood/Kenwood_DMX4704s.ir
@@ -1,0 +1,71 @@
+Filetype: IR signals file
+Version: 1
+# 
+# Remote: Kenwood 
+# Model: Kenwood DMX4707s
+#
+name: Src
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 13 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 14 00 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 15 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 16 00 00 00
+# 
+name: <<Rev
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 0A 00 00 00
+# 
+name: Fwd>>
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 0B 00 00 00
+# 
+name: Play_Pause
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 0E 00 00 00
+# 
+name: AM
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 0C 00 00 00
+# 
+name: FM
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 0D 00 00 00
+# 
+name: Call_answer
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 92 00 00 00
+# 
+name: Call_end
+type: parsed
+protocol: NEC
+address: B9 00 00 00
+command: 88 00 00 00


### PR DESCRIPTION
IR Remote file that uses FlipperZero as infrared remote on this model of Kenwood head unit for car stereo.  Tested, and seems to work fine with my head unit.

The functionality is limited.  I had this trouble with an aftermarket remote I had purchased too.  I believe the infrared system on this head unit is very limited.  The user's manual also only shows the functions here as available on the factory optional remote.

I hope the Pull request is correct, I don't fully understand it.  Please feel free to criticize me!