### PR TITLE
TCL_50S423.ir

### DIFF
--- a/TVs/TCL/TCL_50S423.ir
+++ b/TVs/TCL/TCL_50S423.ir
@@ -1,7 +1,7 @@
 Filetype: IR signals file
 Version: 1
 #
-# TCL Roku TV Remote
+# TCL Roku TV Remote (50S423)
 # https://www.amazon.com/gp/product/B07N4FJ7S4
 # 
 name: Power

--- a/TVs/TCL/TCL_50S423.ir
+++ b/TVs/TCL/TCL_50S423.ir
@@ -1,20 +1,14 @@
 Filetype: IR signals file
 Version: 1
-# 
-# TCL 50S423
-# https://www.amazon.com/gp/product/B07N4FJ7S4
 #
+# TCL Roku TV Remote
+# https://www.amazon.com/gp/product/B07N4FJ7S4
+# 
 name: Power
 type: parsed
 protocol: NECext
 address: EA C7 00 00
 command: 17 E8 00 00
-# 
-name: Mute
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 20 DF 00 00
 # 
 name: Vol_up
 type: parsed
@@ -28,98 +22,104 @@ protocol: NECext
 address: EA C7 00 00
 command: 10 EF 00 00
 # 
-name: Play
+name: Mute
 type: parsed
 protocol: NECext
 address: EA C7 00 00
-command: 4C B3 00 00
+command: 20 DF 00 00
 # 
-name: Media_netflix
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 52 AD 00 00
-# 
-name: Media_sling
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 06 F9 00 00
-# 
-name: Media_hulu
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 4D B2 00 00
-# 
-name: Media_now
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 6C 93 00 00
-# 
-name: Menu_star
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 61 9E 00 00
-# 
-name: Menu_home
+name: Home
 type: parsed
 protocol: NECext
 address: EA C7 00 00
 command: 03 FC 00 00
 # 
-name: Menu_back
+name: Back
 type: parsed
 protocol: NECext
 address: EA C7 00 00
 command: 66 99 00 00
 # 
-name: Nav_ok
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 2A D5 00 00
-# 
-name: FForward
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 55 AA 00 00
-# 
-name: RRewind
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 34 CB 00 00
-# 
-name: Nav_up
+name: Up
 type: parsed
 protocol: NECext
 address: EA C7 00 00
 command: 19 E6 00 00
 # 
-name: Nav_left
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 1E E1 00 00
-# 
-name: Nav_right
-type: parsed
-protocol: NECext
-address: EA C7 00 00
-command: 2D D2 00 00
-# 
-name: Nav_down
+name: Down
 type: parsed
 protocol: NECext
 address: EA C7 00 00
 command: 33 CC 00 00
 # 
-name: Menu_3quarter_circle_b
+name: Left
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 1E E1 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 2D D2 00 00
+# 
+name: Ok
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 2A D5 00 00
+# 
+name: Instant_replay
 type: parsed
 protocol: NECext
 address: EA C7 00 00
 command: 78 87 00 00
+# 
+name: Star
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 61 9E 00 00
+# 
+name: Play/pause
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 4C B3 00 00
+# 
+name: Rewind
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 34 CB 00 00
+# 
+name: Fast-forward
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 55 AA 00 00
+# 
+name: Hulu
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 4D B2 00 00
+# 
+name: Netflix
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 52 AD 00 00
+# 
+name: Sling
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 06 F9 00 00
+# 
+name: Now
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 6C 93 00 00

--- a/TVs/TCL/TCL_50S423.ir
+++ b/TVs/TCL/TCL_50S423.ir
@@ -1,0 +1,125 @@
+Filetype: IR signals file
+Version: 1
+# 
+# TCL 50S423
+# https://www.amazon.com/gp/product/B07N4FJ7S4
+#
+name: Power
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 17 E8 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 20 DF 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 0F F0 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 10 EF 00 00
+# 
+name: Play
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 4C B3 00 00
+# 
+name: Media_netflix
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 52 AD 00 00
+# 
+name: Media_sling
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 06 F9 00 00
+# 
+name: Media_hulu
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 4D B2 00 00
+# 
+name: Media_now
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 6C 93 00 00
+# 
+name: Menu_star
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 61 9E 00 00
+# 
+name: Menu_home
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 03 FC 00 00
+# 
+name: Menu_back
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 66 99 00 00
+# 
+name: Nav_ok
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 2A D5 00 00
+# 
+name: FForward
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 55 AA 00 00
+# 
+name: RRewind
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 34 CB 00 00
+# 
+name: Nav_up
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 19 E6 00 00
+# 
+name: Nav_left
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 1E E1 00 00
+# 
+name: Nav_right
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 2D D2 00 00
+# 
+name: Nav_down
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 33 CC 00 00
+# 
+name: Menu_3quarter_circle_b
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 78 87 00 00


### PR DESCRIPTION
using names from TCL_Roku_TV.ir even though the power signal matches TCL_ROKU_US.ir

if you were trying to make an ultra-generic version of just the roku remote then just make note that these two extra media provider buttons have these codes:
```
# 
name: Sling
type: parsed
protocol: NECext
address: EA C7 00 00
command: 06 F9 00 00
# 
name: Now
type: parsed
protocol: NECext
address: EA C7 00 00
command: 6C 93 00 00
```