### PR TITLE
Add Teufel Cinebar 11

### DIFF
--- a/SoundBars/Teufel/Teufel_Cinebar_11.ir
+++ b/SoundBars/Teufel/Teufel_Cinebar_11.ir
@@ -1,0 +1,134 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: E2 1D 00 00
+# 
+name: Plus
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: FA 05 00 00
+# 
+name: Minus
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: B8 47 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: F6 09 00 00
+# 
+name: Back
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: B4 4B 00 00
+# 
+name: Play_Pause_Select
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: AB 54 00 00
+# 
+name: Left
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: BC 43 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: FE 01 00 00
+# 
+name: Info
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: EE 11 00 00
+# 
+name: Menu
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: AE 51 00 00
+# 
+name: TV
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: B1 4E 00 00
+# 
+name: Bluetooth
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: E0 1F 00 00
+# 
+name: HDMI
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: DB 24 00 00
+# 
+name: Aux
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: DF 20 00 00
+# 
+name: Opt
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: DC 23 00 00
+# 
+name: Display_Brightness
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: F7 08 00 00
+# 
+name: Music
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: BF 40 00 00
+# 
+name: Speech
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: DA 25 00 00
+# 
+name: Night
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: DE 21 00 00
+# 
+name: Dynamic_Sound
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: F1 0E 00 00
+# 
+name: Bass
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: E8 17 00 00
+# 
+name: Treble
+type: parsed
+protocol: NECext
+address: 01 EF 00 00
+command: B0 4F 00 00


### PR DESCRIPTION
Add remote for Teufel Cinebar 11.

Hand-Captured all buttons with Flipper Zero from original remote. Ordered by perceived times of use, grouped by category.